### PR TITLE
v1.0.9

### DIFF
--- a/AssemblyInfo.cs
+++ b/AssemblyInfo.cs
@@ -1,7 +1,7 @@
 using System.Reflection;
 using System.Runtime.InteropServices;
 
-// General Information about an assembly is controlled through the following 
+// General Information about an assembly is controlled through the following
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 [assembly: AssemblyTitle("C Sharp Dev Tools")]
@@ -9,12 +9,12 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("C Sharp Dev Tools")]
-[assembly: AssemblyCopyright("Copyright � 2020 - 2022 Maximilian Kalimon")]
+[assembly: AssemblyCopyright("Copyright � 2020 - 2023 Maximilian Kalimon")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 
-// Setting ComVisible to false makes the types in this assembly not visible 
-// to COM components.  If you need to access a type in this assembly from 
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
 
@@ -24,10 +24,10 @@ using System.Runtime.InteropServices;
 // Version information for an assembly consists of the following four values:
 //
 //      Major Version
-//      Minor Version 
+//      Minor Version
 //      Build Number
 //      Revision
 //
 //
-[assembly: AssemblyVersion("1.0.8")]
-[assembly: AssemblyFileVersion("1.0.8")]
+[assembly: AssemblyVersion("1.0.9")]
+[assembly: AssemblyFileVersion("1.0.9")]

--- a/Assert.Group.cs
+++ b/Assert.Group.cs
@@ -1,0 +1,188 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.IO;
+using System.Reflection;
+using System.Threading.Tasks;
+
+namespace DevTools
+{
+    public static partial class Assert
+    {
+        [AttributeUsage(AttributeTargets.Method, AllowMultiple = false)]
+        internal class GroupAttribute : Attribute
+        {
+            internal const string __FILE__BOOLEAN_CONDITION_CHECKS   = "BOOLEAN_CONDITION_CHECKS";
+            internal const string __FILE__NULL_CHECKS                = "NULL_CHECKS";
+            internal const string __FILE__FILE_PATH_CHECKS           = "FILE_PATH_CHECKS";
+            internal const string __FILE__ARRAY_BOUNDS_CHECKS        = "ARRAY_BOUNDS_CHECKS";
+            internal const string __FILE__COMPARISON_CHECKS          = "COMPARISON_CHECKS";
+            internal const string __FILE__ARITHMETIC_LOGIC_CHECKS    = "ARITHMETIC_LOGIC_CHECKS";
+            internal const string __FILE__MEMORY_CHECKS              = "MEMORY_CHECKS";
+
+            /// <summary> Boolean Condition Checks </summary>
+            internal const string __NAME__BOOLEAN_CONDITION_CHECKS   = "Boolean Condition Checks";
+            /// <summary> Null Checks </summary>
+            internal const string __NAME__NULL_CHECKS                = "Null Checks";
+            /// <summary> File Path Checks </summary>
+            internal const string __NAME__FILE_PATH_CHECKS           = "File Path Checks";
+            /// <summary> Array Bounds Checks </summary>
+            internal const string __NAME__ARRAY_BOUNDS_CHECKS        = "Array Bounds Checks";
+            /// <summary> Comparison Checks </summary>
+            internal const string __NAME__COMPARISON_CHECKS          = "Comparison Checks";
+            /// <summary> Arithmetic-Logic Checks </summary>
+            internal const string __NAME__ARITHMETIC_LOGIC_CHECKS    = "Arithmetic-Logic Checks";
+            /// <summary> Memory Checks </summary>
+            internal const string __NAME__MEMORY_CHECKS              = "Memory Checks";
+
+            private GroupAttribute() { }
+            internal GroupAttribute(string publicName)
+            {
+                PublicName = publicName;
+                FileContent = Defines.Where(grp => grp.PublicName == publicName).First().FileContent;
+            }
+
+            internal string FileContent { get; private set; }
+            internal string PublicName { get; private set; }
+            internal static Assert.GroupAttribute[] Defines => new Assert.GroupAttribute[]
+            {
+                new Assert.GroupAttribute{ FileContent = __FILE__BOOLEAN_CONDITION_CHECKS, PublicName = __NAME__BOOLEAN_CONDITION_CHECKS },
+                new Assert.GroupAttribute{ FileContent = __FILE__NULL_CHECKS,              PublicName = __NAME__NULL_CHECKS              },
+                new Assert.GroupAttribute{ FileContent = __FILE__FILE_PATH_CHECKS,         PublicName = __NAME__FILE_PATH_CHECKS         },
+                new Assert.GroupAttribute{ FileContent = __FILE__ARRAY_BOUNDS_CHECKS,      PublicName = __NAME__ARRAY_BOUNDS_CHECKS      },
+                new Assert.GroupAttribute{ FileContent = __FILE__COMPARISON_CHECKS,        PublicName = __NAME__COMPARISON_CHECKS        },
+                new Assert.GroupAttribute{ FileContent = __FILE__ARITHMETIC_LOGIC_CHECKS,  PublicName = __NAME__ARITHMETIC_LOGIC_CHECKS  },
+                new Assert.GroupAttribute{ FileContent = __FILE__MEMORY_CHECKS,            PublicName = __NAME__MEMORY_CHECKS            }
+            };
+
+            internal static async Task<Dictionary<Assert.GroupAttribute, ulong>> CountMethodCallsAsync(string projectPath)
+            {
+                try
+                {
+                    Dictionary<MethodInfo, Assert.GroupAttribute> methodToGroupMap = GetAssertionsMappedToGroups();
+                    List<Task<Dictionary<Assert.GroupAttribute, ulong>>> jobs = CreateCountingTasks(methodToGroupMap, projectPath);
+
+                    return await CombineResults(jobs, methodToGroupMap);
+                }
+                catch (Exception ex)
+                {
+                    ex.Log();
+                    return null;
+                }
+            }
+
+            private static bool ContainsOverload(Dictionary<MethodInfo, Assert.GroupAttribute> result, MethodInfo method)
+            {
+                foreach (KeyValuePair<MethodInfo, Assert.GroupAttribute> item in result)
+                {
+                    if (item.Key.Name == method.Name)
+                    {
+                        return true;
+                    }
+                }
+
+                return false;
+            }
+            private static Dictionary<MethodInfo, Assert.GroupAttribute> GetAssertionsMappedToGroups()
+            {
+                Dictionary<MethodInfo, Assert.GroupAttribute> result = new Dictionary<MethodInfo, Assert.GroupAttribute>();
+
+                foreach (MethodInfo method in typeof(Assert).GetMethods())
+                {
+                    Assert.GroupAttribute attribute = method.GetCustomAttribute<Assert.GroupAttribute>(false);
+                    if (attribute != null && !ContainsOverload(result, method))
+                    {
+                        result.Add(method, attribute);
+                    }
+                }
+
+                return result;
+            }
+            private static string GetMethodPrefixFromUsingStatements(string script)
+            {
+                if (script.Contains("using static DevTools.Assert;"))
+                {
+                    return string.Empty;
+                }
+                else if (script.Contains("using DevTools;") &&
+                        !script.Contains("using NUnit.Framework;") &&
+                        !script.Contains("using static System.Diagnostics.Debug;"))
+                {
+                    return "Assert.";
+                }
+                else
+                {
+                    return "DevTools.Assert.";
+                }
+            }
+            private static uint CountSubstrings(string instance, string value)
+            {
+Assert.IsFalse(string.IsNullOrEmpty(value));
+
+                uint count = 0;
+                int index = instance.IndexOf(value);
+                while (index != -1 & index < instance.Length)
+                {
+                    count++;
+                    index = instance.IndexOf(value, index + value.Length);
+                }
+
+                return count;
+            }
+            private static List<Task<Dictionary<Assert.GroupAttribute, ulong>>> CreateCountingTasks(Dictionary<MethodInfo, Assert.GroupAttribute> methodToGroupMap, string path)
+            {
+                List<Task<Dictionary<Assert.GroupAttribute, ulong>>> tasks = new List<Task<Dictionary<Assert.GroupAttribute, ulong>>>(256);
+
+                DirectoryExtensions.ForEachFile(path,
+                (file) =>
+                {
+                    if (Path.GetExtension(file) != ".cs")
+                    {
+                        return;
+                    }
+
+                    tasks.Add(Task<Dictionary<Assert.GroupAttribute, ulong>>.Factory.StartNew(
+                    () =>
+                    {
+                        Dictionary<Assert.GroupAttribute, ulong> callCounts = new Dictionary<Assert.GroupAttribute, ulong>();
+                        string script = File.ReadAllText(file);
+                        string prefix = GetMethodPrefixFromUsingStatements(script);
+
+                        foreach (KeyValuePair<MethodInfo, Assert.GroupAttribute> methodMapping in methodToGroupMap)
+                        {
+                            Assert.GroupAttribute group = methodMapping.Value;
+                            ulong numCalls = CountSubstrings(script, prefix + methodMapping.Key.Name);
+
+                            if (callCounts.ContainsKey(group))
+                            {
+                                callCounts[group] += numCalls;
+                            }
+                            else
+                            {
+                                callCounts.Add(group, numCalls);
+                            }
+                        }
+
+                        return callCounts;
+                    }));
+                });
+
+                return tasks;
+            }
+            private static async Task<Dictionary<Assert.GroupAttribute, ulong>> CombineResults(List<Task<Dictionary<Assert.GroupAttribute, ulong>>> jobs, Dictionary<MethodInfo, Assert.GroupAttribute> methodToGroupMap)
+            {
+                Dictionary<Assert.GroupAttribute, ulong> result = await jobs[0]; // at the very least this very script is assigned a job
+
+                for (int i = 1; i < jobs.Count; i++)
+                {
+                    foreach (KeyValuePair<Assert.GroupAttribute, ulong> callCount in await jobs[i])
+                    {
+                        result[callCount.Key] += callCount.Value;
+                    }
+                }
+
+                return result;
+            }
+        }
+    }
+}

--- a/Assert.Group.cs.meta
+++ b/Assert.Group.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 3a77b5ee8b1a45047bb10197e1025b08
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Dump.cs
+++ b/Dump.cs
@@ -64,7 +64,7 @@ Assert.IsNonNegative(bytes);
         {
 Assert.IsNotNull(ptr);
 Assert.IsNonNegative(bytes);
-            
+
             char* HEX_VALUES = stackalloc char[] { '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'A', 'B', 'C', 'D', 'E', 'F' };
 
             byte* address = (byte*)ptr;

--- a/Extensions/DirectoryExtensions.cs
+++ b/Extensions/DirectoryExtensions.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.IO;
 using System.Collections.Generic;
 
@@ -29,7 +29,7 @@ namespace DevTools
                     return result;
                 }
             }
-        
+
             return null;
         }
 
@@ -37,7 +37,7 @@ namespace DevTools
         public static void DeleteFolder(string folder)
         {
             ForEachDirectory(folder,
-            (__folder) => 
+            (__folder) =>
             {
                 foreach (string file in Directory.GetFiles(__folder))
                 {

--- a/Extensions/GenericExtensions.cs
+++ b/Extensions/GenericExtensions.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 
 namespace DevTools
 {

--- a/Unity/Editor/DebugBurstIntrinsicsWindow.cs
+++ b/Unity/Editor/DebugBurstIntrinsicsWindow.cs
@@ -1,0 +1,364 @@
+#if UNITY_EDITOR
+using System.IO;
+using UnityEngine;
+using UnityEditor;
+
+namespace DevTools.Unity.Editor
+{
+    internal class DebugBurstIntrinsicsWindow : EditorWindow
+    {
+        private static string ProjectPath => Application.dataPath.Substring(0, Application.dataPath.Length - "Assets".AsDirectory().Length).AsDirectory() + "LocalPackages";
+
+        private const string SSE    = "Sse.IsSseSupported";
+        private const string SSE2   = "Sse2.IsSse2Supported";
+        private const string SSE3   = "Sse3.IsSse3Supported";
+        private const string SSSE3  = "Ssse3.IsSsse3Supported";
+        private const string SSE4_1 = "Sse4_1.IsSse41Supported";
+        private const string SSE4_2 = "Sse4_2.IsSse42Supported";
+        private const string AVX    = "Avx.IsAvxSupported";
+        private const string AVX2   = "Avx2.IsAvx2Supported";
+        private const string FMA    = "Fma.IsFmaSupported";
+        private const string BMI1   = "Bmi1.IsBmi1Supported";
+        private const string BMI2   = "Bmi2.IsBmi2Supported";
+        private const string POPCNT = "Popcnt.IsPopcntSupported";
+        private const string F16C   = "F16C.IsF16CSupported";
+
+        private const string CONST = "Constant.IsConstantExpression";
+
+        private const string TESTING = "#define TESTING";
+
+
+        private static bool SkipFile(string file)
+        {
+            return Path.GetExtension(file) != ".cs" || Path.GetFileNameWithoutExtension(file) == "DebugBurstIntrinsicsWindow";
+        }
+
+        private static void DeactivateAll()
+        {
+            DeactivateFeatureSet(SSE);
+            DeactivateFeatureSet(SSE2);
+            DeactivateFeatureSet(SSE3);
+            DeactivateFeatureSet(SSSE3);
+            DeactivateFeatureSet(SSE4_1);
+            DeactivateFeatureSet(SSE4_2);
+            DeactivateFeatureSet(AVX);
+            DeactivateFeatureSet(AVX2);
+            DeactivateFeatureSet(FMA);
+            DeactivateFeatureSet(BMI1);
+            DeactivateFeatureSet(BMI2);
+            DeactivateFeatureSet(POPCNT);
+            DeactivateFeatureSet(F16C);
+        }
+
+        private static void DeactivatePreprocessorDirective(string define)
+        {
+            DirectoryExtensions.ForEachFile(ProjectPath,
+            (file) =>
+            {
+                if (SkipFile(file))
+                {
+                    return;
+                }
+
+                string fileContent = File.ReadAllText(file);
+
+                if (!fileContent.Contains("//" + define))
+                {
+                    fileContent = fileContent.Replace(define, "//" + define);
+                    File.WriteAllText(file, fileContent);
+                }
+            });
+        }
+
+        private static void ActivatePreprocessorDirective(string define)
+        {
+            DirectoryExtensions.ForEachFile(ProjectPath,
+            (file) =>
+            {
+                if (SkipFile(file))
+                {
+                    return;
+                }
+
+                string fileContent = File.ReadAllText(file);
+
+                if (fileContent.Contains("//" + define))
+                {
+                    fileContent = fileContent.Replace("//" + define, define);
+                    File.WriteAllText(file, fileContent);
+                }
+            });
+        }
+
+        private static void DeactivateFeatureSet(string featureSet)
+        {
+            DirectoryExtensions.ForEachFile(ProjectPath,
+            (file) =>
+            {
+                if (SkipFile(file))
+                {
+                    return;
+                }
+
+                string fileContent = File.ReadAllText(file);
+
+                bool any = false;
+                int index = 0;
+                while ((index = fileContent.IndexOf("!" + featureSet, index + 1)) != -1)
+                {
+                    any = true;
+                    fileContent = fileContent.Remove(index, 1);
+                }
+
+                if (any)
+                {
+                    File.WriteAllText(file, fileContent);
+                }
+            });
+        }
+
+        private static void ActivateFeatureSet(string featureSet)
+        {
+            DirectoryExtensions.ForEachFile(ProjectPath,
+            (file) =>
+            {
+                if (SkipFile(file))
+                {
+                    return;
+                }
+
+                string fileContent = File.ReadAllText(file);
+
+                bool any = false;
+                int index = 0;
+                while ((index = fileContent.IndexOf(featureSet, index + 1)) != -1)
+                {
+                    any = true;
+                    if (fileContent[index - 1] != '!')
+                    {
+                        fileContent = fileContent.Insert(index, "!");
+                        index++;
+                    }
+                }
+
+                if (any)
+                {
+                    File.WriteAllText(file, fileContent);
+                }
+            });
+        }
+
+
+        public static void ACTIVATE_TEST_MODE()
+        {
+            ActivatePreprocessorDirective(TESTING);
+
+            AssetDatabase.Refresh();
+        }
+
+        public static void ACTIVATE_SSE()
+        {
+            DeactivateAll();
+
+            ActivateFeatureSet(SSE);
+
+            AssetDatabase.Refresh();
+        }
+
+        public static void ACTIVATE_SSE2()
+        {
+            DeactivateAll();
+
+            ActivateFeatureSet(SSE);
+            ActivateFeatureSet(SSE2);
+
+            AssetDatabase.Refresh();
+        }
+
+        public static void ACTIVATE_SSE3()
+        {
+            DeactivateAll();
+
+            ActivateFeatureSet(SSE);
+            ActivateFeatureSet(SSE2);
+            ActivateFeatureSet(SSE3);
+
+            AssetDatabase.Refresh();
+        }
+
+        public static void ACTIVATE_SSSE3()
+        {
+            DeactivateAll();
+
+            ActivateFeatureSet(SSE);
+            ActivateFeatureSet(SSE2);
+            ActivateFeatureSet(SSE3);
+            ActivateFeatureSet(SSSE3);
+
+            AssetDatabase.Refresh();
+        }
+
+        public static void ACTIVATE_SSE4_1()
+        {
+            DeactivateAll();
+
+            ActivateFeatureSet(SSE);
+            ActivateFeatureSet(SSE2);
+            ActivateFeatureSet(SSE3);
+            ActivateFeatureSet(SSSE3);
+            ActivateFeatureSet(SSE4_1);
+
+            AssetDatabase.Refresh();
+        }
+
+        public static void ACTIVATE_SSE4_2()
+        {
+            DeactivateAll();
+
+            ActivateFeatureSet(SSE);
+            ActivateFeatureSet(SSE2);
+            ActivateFeatureSet(SSE3);
+            ActivateFeatureSet(SSSE3);
+            ActivateFeatureSet(SSE4_1);
+            ActivateFeatureSet(SSE4_2);
+
+            AssetDatabase.Refresh();
+        }
+
+        public static void ACTIVATE_AVX()
+        {
+            DeactivateAll();
+
+            ActivateFeatureSet(SSE);
+            ActivateFeatureSet(SSE2);
+            ActivateFeatureSet(SSE3);
+            ActivateFeatureSet(SSSE3);
+            ActivateFeatureSet(SSE4_1);
+            ActivateFeatureSet(SSE4_2);
+            ActivateFeatureSet(AVX);
+
+            AssetDatabase.Refresh();
+        }
+
+        public static void ACTIVATE_AVX2()
+        {
+            DeactivateAll();
+
+            ActivateFeatureSet(SSE);
+            ActivateFeatureSet(SSE2);
+            ActivateFeatureSet(SSE3);
+            ActivateFeatureSet(SSSE3);
+            ActivateFeatureSet(SSE4_1);
+            ActivateFeatureSet(SSE4_2);
+            ActivateFeatureSet(AVX);
+            ActivateFeatureSet(AVX2);
+            ActivateFeatureSet(FMA);
+            ActivateFeatureSet(BMI1);
+            ActivateFeatureSet(BMI2);
+            ActivateFeatureSet(POPCNT);
+            ActivateFeatureSet(F16C);
+
+            AssetDatabase.Refresh();
+        }
+
+        public static void ACTIVATE_CONST()
+        {
+            DeactivateFeatureSet(CONST);
+
+            ActivateFeatureSet(CONST);
+
+            AssetDatabase.Refresh();
+        }
+
+        public static void RELEASE_MODE()
+        {
+            DeactivatePreprocessorDirective(TESTING);
+
+            DeactivateAll();
+
+            DeactivateFeatureSet(CONST);
+
+            AssetDatabase.Refresh();
+        }
+
+        private static void DrawLine()
+        {
+            Rect r = EditorGUILayout.GetControlRect(GUILayout.Height(1));
+            r.height = 1;
+            r.x -= 2 ;
+            r.width += 6;
+            EditorGUI.DrawRect(r, Color.black);
+        }
+
+
+        [MenuItem("Window/C# Dev Tools/Debug Burst Intrinsics (Local Packages Only)")]
+        private static void ShowWindow()
+        {
+            GetWindow<DebugBurstIntrinsicsWindow>("Debug Burst Intrinsics");
+        }
+
+        private void OnGUI()
+        {
+            GUILayout.Label("Set Code Path:");
+
+            if (GUILayout.Button("SSE", GUILayout.ExpandWidth(false)))
+            {
+                ACTIVATE_SSE();
+            }
+            if (GUILayout.Button("SSE2", GUILayout.ExpandWidth(false)))
+            {
+                ACTIVATE_SSE2();
+            }
+            if (GUILayout.Button("SSE3", GUILayout.ExpandWidth(false)))
+            {
+                ACTIVATE_SSE3();
+            }
+            if (GUILayout.Button("SSSE3", GUILayout.ExpandWidth(false)))
+            {
+                ACTIVATE_SSSE3();
+            }
+            if (GUILayout.Button("SSE4.1", GUILayout.ExpandWidth(false)))
+            {
+                ACTIVATE_SSE4_1();
+            }
+            if (GUILayout.Button("SSE4.2", GUILayout.ExpandWidth(false)))
+            {
+                ACTIVATE_SSE4_2();
+            }
+            if (GUILayout.Button("AVX", GUILayout.ExpandWidth(false)))
+            {
+                ACTIVATE_AVX();
+            }
+            if (GUILayout.Button("AVX2", GUILayout.ExpandWidth(false)))
+            {
+                ACTIVATE_AVX2();
+            }
+
+            GUILayout.Space(10);
+
+            if (GUILayout.Button("IsConstantExpression", GUILayout.ExpandWidth(false)))
+            {
+                ACTIVATE_CONST();
+            }
+
+            GUILayout.Space(10);
+
+            if (GUILayout.Button("Activate 'TESTING' Preprocessor Directive", GUILayout.ExpandWidth(false)))
+            {
+                ACTIVATE_TEST_MODE();
+            }
+
+            GUILayout.Space(5);
+
+            DrawLine();
+
+            GUILayout.Space(5);
+
+            if (GUILayout.Button("Reset to Release Mode", GUILayout.ExpandWidth(false)))
+            {
+                RELEASE_MODE();
+            }
+        }
+    }
+}
+#endif

--- a/Unity/Editor/DebugBurstIntrinsicsWindow.cs.meta
+++ b/Unity/Editor/DebugBurstIntrinsicsWindow.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 221517bbab969584faff302f516e5894
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Unity/Editor/SafetyCheckSettingsWindow.cs
+++ b/Unity/Editor/SafetyCheckSettingsWindow.cs
@@ -22,22 +22,22 @@ namespace DevTools.Unity.Editor
 
         private Dictionary<Assert.GroupAttribute, ulong> methodCallCounts = null;
         private Dictionary<Assert.GroupAttribute, bool> definesToCheckMarks;
-        
+
 
         private static string ProjectPath => Application.dataPath.Substring(0, Application.dataPath.Length - "Assets".AsDirectory().Length);
-        private static string ScriptPath 
+        private static string ScriptPath
         {
-            get 
+            get
             {
                 string defaultPath = ProjectPath.AsDirectory() + "LocalPackages".AsDirectory() + FOLDER_NAME.AsDirectory() + FILE_NAME;
-                
+
                 if (File.Exists(defaultPath))
                 {
                     return defaultPath;
                 }
                 else
                 {
-                    return DirectoryExtensions.FindInFolder(ProjectPath, FILE_NAME) ?? throw new DllNotFoundException($"'{ FOLDER_NAME.AsDirectory() + FILE_NAME }' was modified and cannot be found.");
+                    return DirectoryExtensions.FindInFolder(ProjectPath, FILE_NAME) ?? throw new DllNotFoundException($"'{ FOLDER_NAME.AsDirectory() + FILE_NAME }' was modified and cannot be found. Enabling/Disabling assertions in the editor is not supported.");
                 }
             }
         }
@@ -59,10 +59,10 @@ namespace DevTools.Unity.Editor
 
         private bool AllChecks
         {
-            get 
+            get
             {
                 bool result = true;
-            
+
                 foreach (KeyValuePair<Assert.GroupAttribute, bool> checkMark in definesToCheckMarks.ToList())
                 {
                     result &= definesToCheckMarks[checkMark.Key];
@@ -106,7 +106,7 @@ namespace DevTools.Unity.Editor
             {
                 fileContent = UpdateCondition(fileContent, map.Key);
             }
-            
+
             anythingChanged = false;
 
             reader.Dispose();
@@ -125,7 +125,7 @@ Assert.IsFalse(IsEnabled(fileContent, assertionGroup));
 
             return fileContent.Remove(fileContent.IndexOf("#define " + assertionGroup.FileContent) - 2, 2);
         }
-        
+
         private string Disable(string fileContent, Assert.GroupAttribute assertionGroup)
         {
 Assert.IsTrue(IsEnabled(fileContent, assertionGroup));
@@ -138,9 +138,9 @@ Assert.IsTrue(IsEnabled(fileContent, assertionGroup));
             bool loading = methodCallCounts == null;
             ulong calls = key == null ? (loading ? 0 : TotalMethodCalls) : (loading ? 0 : methodCallCounts[key]);
 
-            return " (" + 
-                   (loading ? LOADING : calls.ToString()) + 
-                   " call" + (calls == 1 ? string.Empty : "s") + 
+            return " (" +
+                   (loading ? LOADING : calls.ToString()) +
+                   " call" + (calls == 1 ? string.Empty : "s") +
                    ")";
         }
 
@@ -152,17 +152,17 @@ Assert.IsTrue(IsEnabled(fileContent, assertionGroup));
         }
 
         private void OnEnable()
-        {   
+        {
             string projectPath = ProjectPath; // <- Only allowed on the main thread in Unity
             string scriptPath = ScriptPath; // <- Only allowed on the main thread in Unity
 
-            Task.Run(() => 
+            Task.Run(() =>
             {
                 try
                 {
                     StreamReader reader = new StreamReader(scriptPath);
                     string fileContent = reader.ReadToEnd();
-                    reader.Dispose();            
+                    reader.Dispose();
 
                     Assert.GroupAttribute[] defines = Assert.GroupAttribute.Defines;
                     definesToCheckMarks = new Dictionary<Assert.GroupAttribute, bool>(defines.Length);
@@ -189,9 +189,9 @@ Assert.IsTrue(IsEnabled(fileContent, assertionGroup));
 
 
             bool _allChecks = GUILayout.Toggle(AllChecks, "  " + ALL_CHECKS + GetAssertionGroupCallCountSuffix(null));
-            
+
             GUILayout.Space(10);
-            
+
             const byte OFFSET_BETWEEN_CHECKBOXES = 2;
             bool* conditions = stackalloc bool[definesToCheckMarks.Count];
             int iterations = 0;
@@ -202,9 +202,9 @@ Assert.IsTrue(IsEnabled(fileContent, assertionGroup));
             }
 
             GUILayout.Space(15 - OFFSET_BETWEEN_CHECKBOXES);
-            
+
             bool _anythingChanged = _allChecks != AllChecks;
-            
+
             if (_anythingChanged)
             {
                 AllChecks = _allChecks;
@@ -227,7 +227,7 @@ Assert.IsTrue(IsEnabled(fileContent, assertionGroup));
             {
                 WriteToFile();
             }
-            
+
             GUILayout.Space(10);
         }
     }

--- a/UnreachableException.cs
+++ b/UnreachableException.cs
@@ -1,0 +1,13 @@
+﻿using System;
+
+namespace DevTools
+{
+    public class UnreachableException : Exception
+    {
+        public UnreachableException()
+            : base($"{ Assert.ASSERTION_FAILED_TAG } Attempted to execute unreachable code.")
+        {
+
+        }
+    }
+}

--- a/UnreachableException.cs.meta
+++ b/UnreachableException.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 20b51057f15ede64596b3a77fc2a4367
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "csharpdevtools",
   "displayName": "C Sharp Dev Tools",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "description": "C Sharp Dev Tools is a small framework for defensive development with conditionally compiled assertions and logging tools.",
   "author": {
     "name": "Maximilian Kalimon",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "csharpdevtools",
   "displayName": "C Sharp Dev Tools",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "description": "C Sharp Dev Tools is a small framework for defensive development with conditionally compiled assertions and logging tools.",
   "author": {
     "name": "Maximilian Kalimon",


### PR DESCRIPTION
### Additions

- added `IEnumerable<T> ForEachDirectory<T>(string folder, Func<string, T> func)` to `DirectoryExtensions`
- added `IEnumerable<T> ForEachFile<T>(string folder, Func<string, T> func)` to `DirectoryExtensions`
- added `DebugBurstIntrinsicsWindow` if used within a Unity project as an editor window (Window/C# Dev Tools/Debug Burst Intrinsics (Local Packages Only)), enabling source code modification of used Unity.Burst compiler intrinsics within the `LocalPackages` folder
- added `AreNotAliased` and `AreNotAliased<T, U>` assertions to ensure that pointers i.e. arrays do not overlap
- added `UnreachableException` and an accompanying assertion `Assert.Unreachable()`, mainly to replace the `default: throw null`/`new Exception("unreachable code")` pattern in switch statements with `default: throw Assert.Unreachable()`

## Improvements

- added a more recognizable error message prefix "Assertion failed:" to all assertions

## Fixes

- fixed incorrect call counts of assertions being displayed in the Unity editor control window (Window/C# Dev Tools/Manage Safety Checks...)

### Fixed Oversights

- included `.meta` files to allow for adding the repository to Unity projects via its GitHub URL