### PR TITLE
v1.0.10

### DIFF
--- a/AssemblyInfo.cs
+++ b/AssemblyInfo.cs
@@ -9,7 +9,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("C Sharp Dev Tools")]
-[assembly: AssemblyCopyright("Copyright � 2020 - 2023 Maximilian Kalimon")]
+[assembly: AssemblyCopyright("Copyright � 2020 - 2024 Maximilian Kalimon")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 
@@ -29,5 +29,5 @@ using System.Runtime.InteropServices;
 //      Revision
 //
 //
-[assembly: AssemblyVersion("1.0.9")]
-[assembly: AssemblyFileVersion("1.0.9")]
+[assembly: AssemblyVersion("1.0.10")]
+[assembly: AssemblyFileVersion("1.0.10")]

--- a/Assert.cs
+++ b/Assert.cs
@@ -505,7 +505,7 @@ namespace DevTools
             where T : IComparable<T>
         {
 #if COMPARISON_CHECKS
-            if (value.CompareTo(limit) == 1)
+            if (value.CompareTo(limit) > 0)
             {
                 throw new ArgumentOutOfRangeException(ASSERTION_FAILED_TAG + $"{ value } was expected to be smaller than or equal to { limit }.");
             }
@@ -519,7 +519,7 @@ namespace DevTools
             where T : IComparable<T>
         {
 #if COMPARISON_CHECKS
-            if (value.CompareTo(limit) != -1)
+            if (value.CompareTo(limit) > -1)
             {
                 throw new ArgumentOutOfRangeException(ASSERTION_FAILED_TAG + $"{ value } was expected to be smaller than { limit }.");
             }
@@ -533,7 +533,7 @@ namespace DevTools
             where T : IComparable<T>
         {
 #if COMPARISON_CHECKS
-            if (value.CompareTo(limit) == -1)
+            if (value.CompareTo(limit) < 0)
             {
                 throw new ArgumentOutOfRangeException(ASSERTION_FAILED_TAG + $"{ value } was expected to be greater than or equal to { limit }.");
             }
@@ -547,7 +547,7 @@ namespace DevTools
             where T : IComparable<T>
         {
 #if COMPARISON_CHECKS
-            if (value.CompareTo(limit) != 1)
+            if (value.CompareTo(limit) < 1)
             {
                 throw new ArgumentOutOfRangeException(ASSERTION_FAILED_TAG + $"{ value } was expected to be greater than { limit }.");
             }
@@ -561,7 +561,7 @@ namespace DevTools
             where T : IComparable<T>
         {
 #if COMPARISON_CHECKS
-            if (value.CompareTo(limit) == -1)
+            if (value.CompareTo(limit) < 0)
             {
                 throw new ArgumentOutOfRangeException(ASSERTION_FAILED_TAG + $"{ value } was expected not to be smaller than { limit }.");
             }
@@ -575,7 +575,7 @@ namespace DevTools
             where T : IComparable<T>
         {
 #if COMPARISON_CHECKS
-            if (value.CompareTo(limit) == 1)
+            if (value.CompareTo(limit) > 0)
             {
                 throw new ArgumentOutOfRangeException(ASSERTION_FAILED_TAG + $"{ value } was expected not to be greater than { limit }.");
             }

--- a/Unity/Editor/SafetyCheckSettingsWindow.cs
+++ b/Unity/Editor/SafetyCheckSettingsWindow.cs
@@ -20,7 +20,7 @@ namespace DevTools.Unity.Editor
         private bool firstLoad;
         private bool anythingChanged;
 
-        private Dictionary<Assert.GroupAttribute, ulong> methodCallCounts = null;
+        private Dictionary<Assert.GroupAttribute, uint> methodCallCounts = null;
         private Dictionary<Assert.GroupAttribute, bool> definesToCheckMarks;
 
 
@@ -48,7 +48,7 @@ namespace DevTools.Unity.Editor
             {
                 ulong count = 0;
 
-                foreach (KeyValuePair<Assert.GroupAttribute, ulong> assertion in methodCallCounts)
+                foreach (KeyValuePair<Assert.GroupAttribute, uint> assertion in methodCallCounts)
                 {
                     count += assertion.Value;
                 }

--- a/UnreachableException.cs
+++ b/UnreachableException.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 
 namespace DevTools
 {

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "csharpdevtools",
   "displayName": "C Sharp Dev Tools",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "description": "C Sharp Dev Tools is a small framework for defensive development with conditionally compiled assertions and logging tools.",
   "author": {
     "name": "Maximilian Kalimon",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "csharpdevtools",
   "displayName": "C Sharp Dev Tools",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "description": "C Sharp Dev Tools is a small framework for defensive development with conditionally compiled assertions and logging tools.",
   "author": {
     "name": "Maximilian Kalimon",


### PR DESCRIPTION
## Fixes

- fixed `COMPARISON_CHECKS` assertions' `CompareTo` calls to allow for `T` being of the type `byte`, as `byte.CompareTo` does not necessarily only return 0, 1 and -1

## Improvements

- reduced memory footprint in the Unity Editor slightly